### PR TITLE
Adding Puli integration to GlideModule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,10 @@
         "php": ">=5.4",
         "container-interop/service-provider": "~0.2.0",
         "league/glide": "^1.0"
-    }
+    },
+    "require-dev": {
+        "puli/composer-plugin": "^1.0"
+    },
+    "minimum-stability": "beta",
+    "prefer-stable": true
 }

--- a/puli.json
+++ b/puli.json
@@ -1,0 +1,100 @@
+{
+    "version": "1.0",
+    "name": "mnapoli/glide-module",
+    "bindings": {
+        "e911f819-9135-4952-abc3-e9ce6c571332": {
+            "_class": "Puli\\Discovery\\Binding\\ClassBinding",
+            "class": "GlideModule\\GlideServiceProvider",
+            "type": "container-interop/service-provider"
+        }
+    },
+    "config": {
+        "bootstrap-file": "vendor/autoload.php"
+    },
+    "packages": {
+        "container-interop/container-interop": {
+            "install-path": "vendor/container-interop/container-interop",
+            "installer": "composer"
+        },
+        "container-interop/service-provider": {
+            "install-path": "vendor/container-interop/service-provider",
+            "installer": "composer"
+        },
+        "guzzlehttp/psr7": {
+            "install-path": "vendor/guzzlehttp/psr7",
+            "installer": "composer"
+        },
+        "intervention/image": {
+            "install-path": "vendor/intervention/image",
+            "installer": "composer"
+        },
+        "justinrainbow/json-schema": {
+            "install-path": "vendor/justinrainbow/json-schema",
+            "installer": "composer"
+        },
+        "league/flysystem": {
+            "install-path": "vendor/league/flysystem",
+            "installer": "composer"
+        },
+        "league/glide": {
+            "install-path": "vendor/league/glide",
+            "installer": "composer"
+        },
+        "psr/http-message": {
+            "install-path": "vendor/psr/http-message",
+            "installer": "composer"
+        },
+        "psr/log": {
+            "install-path": "vendor/psr/log",
+            "installer": "composer"
+        },
+        "puli/composer-plugin": {
+            "install-path": "vendor/puli/composer-plugin",
+            "installer": "composer"
+        },
+        "puli/discovery": {
+            "install-path": "vendor/puli/discovery",
+            "installer": "composer"
+        },
+        "puli/repository": {
+            "install-path": "vendor/puli/repository",
+            "installer": "composer"
+        },
+        "puli/url-generator": {
+            "install-path": "vendor/puli/url-generator",
+            "installer": "composer"
+        },
+        "ramsey/uuid": {
+            "install-path": "vendor/ramsey/uuid",
+            "installer": "composer"
+        },
+        "seld/jsonlint": {
+            "install-path": "vendor/seld/jsonlint",
+            "installer": "composer"
+        },
+        "symfony/process": {
+            "install-path": "vendor/symfony/process",
+            "installer": "composer"
+        },
+        "webmozart/assert": {
+            "install-path": "vendor/webmozart/assert",
+            "installer": "composer"
+        },
+        "webmozart/expression": {
+            "install-path": "vendor/webmozart/expression",
+            "installer": "composer"
+        },
+        "webmozart/glob": {
+            "install-path": "vendor/webmozart/glob",
+            "installer": "composer"
+        },
+        "webmozart/json": {
+            "install-path": "vendor/webmozart/json",
+            "installer": "composer"
+        },
+        "webmozart/path-util": {
+            "install-path": "vendor/webmozart/path-util",
+            "installer": "composer"
+        }
+    }
+}

--- a/src/GlideServiceProvider.php
+++ b/src/GlideServiceProvider.php
@@ -5,7 +5,7 @@ namespace GlideModule;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
 use Interop\Container\ContainerInterface;
-use Interop\Container\ServiceProvider\ServiceProvider;
+use Interop\Container\ServiceProvider;
 use League\Glide\Responses\PsrResponseFactory;
 use League\Glide\Server;
 use League\Glide\ServerFactory;


### PR DESCRIPTION
I was in the process of testing Puli integration with the Symfony bridge. I needed a package with a service provider. I said to myself: "hey, the glide-module" is the only service-provider package we have so far :)

So here we go: Puli bindings for the glide-module.

I had to add `puli/composer-plugin` to composer.json, otherwise, Puli would not generate a puli.json file that works. I'm pretty sure it can be removed. I let it in the `require-dev` section, thinking it could be useful to update the puli.json, should the format change.

Also, I successfully tested this fork with the new version of the Symfony bridge. :)
